### PR TITLE
Add 'display: flex' rule to use-cases class

### DIFF
--- a/style/main.sass
+++ b/style/main.sass
@@ -34,6 +34,7 @@ main
     padding-top: 0
 
     .use-cases
+      display: flex
       h2.title
         margin-bottom: 60px
 


### PR DESCRIPTION
The _"Use cases"_ website section shows a box misalignment when the content doesn't match the other boxes paragraph line count. `Flexbox` stretches the boxes vertically so they all will be the same height.

Tested on:

```
Google Chrome        v44
Mozilla Firefox      v39.0
Safari               v8.0.8
Microsoft Edge       v20
Internet Explorer    v11 , v10, v9
```
