### PR TITLE
Fix translation files paths

### DIFF
--- a/es/contributing.jade
+++ b/es/contributing.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_contributing.jade
+include ../markup/templates/_contributing.jade

--- a/es/download.jade
+++ b/es/download.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_download.jade
+include ../markup/templates/_download.jade

--- a/es/modules.jade
+++ b/es/modules.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_modules.jade
+include ../markup/templates/_modules.jade

--- a/es/showcase.jade
+++ b/es/showcase.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_showcase.jade
+include ../markup/templates/_showcase.jade

--- a/es/start.jade
+++ b/es/start.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_start.jade
+include ../markup/templates/_start.jade

--- a/markup/molecules/_menu.jade
+++ b/markup/molecules/_menu.jade
@@ -6,7 +6,7 @@ ul.menu.list-horz.list-plain
 	+menu_link('modules.html', commonTerms.modules[language])
 	//- +menu_link('showcase.html', 'Showcase')
 	+menu_link('contributing.html', commonTerms.contributing[language])
-	+language_link('/en', 'EN', 'first')
+	+language_link('/', 'EN', 'first')
 	+language_link('/pt', 'PT')
 	+language_link('/es', 'ES', 'last')
 	li.styleguide-github-star

--- a/pt/contributing.jade
+++ b/pt/contributing.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_contributing.jade
+include ../markup/templates/_contributing.jade

--- a/pt/download.jade
+++ b/pt/download.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_download.jade
+include ../markup/templates/_download.jade

--- a/pt/index.jade
+++ b/pt/index.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_home.jade
+!=partial('../markup/templates/_home', { language: public.pt._data.language })

--- a/pt/modules.jade
+++ b/pt/modules.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_modules.jade
+include ../markup/templates/_modules.jade

--- a/pt/showcase.jade
+++ b/pt/showcase.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_showcase.jade
+include ../markup/templates/_showcase.jade

--- a/pt/start.jade
+++ b/pt/start.jade
@@ -1,1 +1,1 @@
-include ./markup/templates/_start.jade
+include ../markup/templates/_start.jade


### PR DESCRIPTION
- Add additional dots at the beginning of the relative paths for the translation docs for **Spanish** and **Portuguese** translations
- Remove the `en` part of the relative path included `_menu.jade` partial for the English translation link
