### PR TITLE
Fix github link text

### DIFF
--- a/markup/molecules/_action.jade
+++ b/markup/molecules/_action.jade
@@ -1,4 +1,4 @@
 .action
 	include ./_download.jade
-	+button_primary('https://github.com/hugeinc/styleguide', public._data.commonTerms.downloadZip[language], '_blank')
+	+button_primary('https://github.com/hugeinc/styleguide', public._data.commonTerms.repository[language], '_blank')
 	+button_primary('http://hugeinc.github.io/styleguide/demo/index.html', public._data.commonTerms.demo[language], '_blank')


### PR DESCRIPTION
I have no idea if this works (haven't tested) -- this website is pretty complex. Should fix the button text, though! :wink: 

![image](https://cloud.githubusercontent.com/assets/2166114/10910772/e537c292-8206-11e5-9ed6-de7eef1250fe.png)
