### PR TITLE
Fix download link

### DIFF
--- a/markup/templates/_start.jade
+++ b/markup/templates/_start.jade
@@ -33,7 +33,7 @@ main.inner
 					.ten.columns.center
 						+title(commonTerms.windowsLinux[language])
 						!=partial(windowsLinux)
-						+button_primary('https://github.com/hugeinc/styleguide/archive/windows-linux.zip', commonTerms.downloadWindows[language])
+						+button_primary('https://github.com/hugeinc/styleguide/archive/release/windows-linux.zip', commonTerms.downloadWindows[language])
 		.section.u-cf.inner#manual-install
 			.container
 				.row


### PR DESCRIPTION
Windows / Linux download link fixed
https://github.com/hugeinc/styleguide/archive/windows-linux.zip
replaced by
https://github.com/hugeinc/styleguide/archive/release/windows-linux.zip
